### PR TITLE
Absolutely position the pane instead of the container

### DIFF
--- a/src/sass/ui/pane.scss
+++ b/src/sass/ui/pane.scss
@@ -9,12 +9,6 @@ $browserPrefix: 'chrome-extension://__MSG_@@extension_id__' !default;
     $browserPrefix: 'ms-browser-extension://__MSG_@@extension_id__';
 }
 
-.crm-power-pane-container {
-    position: absolute;
-    top: 50px;
-    width: 100%;
-}
-
 .lookup-link {
     background: url('#{$browserPrefix}/img/lookup-link.png');
     background-size: 16px;
@@ -53,6 +47,8 @@ $browserPrefix: 'chrome-extension://__MSG_@@extension_id__' !default;
 }
 
 .crm-power-pane-sections {
+    position: absolute;
+    top: 50px;
     display: none;
     width: 100%;
     position: absolute;


### PR DESCRIPTION
**Description**
Absolutely positioning the container breaks the dialogs, and we only need the pane
to be absolute.

Fixes #58

**Code Review Checklist**

- [x] I completed a complete self-review of my contribution.

I tested the extension for the following browsers:
  - [x] Google Chrome
  - [ ] Mozilla Firefox
  - [ ] Microsoft Edge

I tested the extension on the following versions of the product:
 - [x] Dynamics 365 v9
 - [x] Dynamics 365 v8.2
